### PR TITLE
Refacto/group model

### DIFF
--- a/sources/api/controllers/GroupController.ts
+++ b/sources/api/controllers/GroupController.ts
@@ -1,7 +1,3 @@
-//
-// Created by benard-g on 2018/10/08
-//
-
 import {Response, Request} from "express";
 import {Repository} from "typeorm";
 import {getRequestingUser} from "../middleware/loggedOnly";
@@ -74,8 +70,7 @@ export async function groupInfo(req: Request, res: Response) {
 
     const conn = await DbConnection.getConnection();
     const groupRepository = conn.getRepository(Group);
-    const userRepository = conn.getRepository(User);
-    const group = await Group.getGroupInfo(groupRepository, userRepository, groupId);
+    const group = await Group.getGroupInfo(groupRepository, groupId);
 
     if (!group
         || group.members.findIndex(member => member.id === requestingUser.id) < 0) {
@@ -114,8 +109,7 @@ export async function deleteGroup(req: Request, res: Response) {
 
     const conn = await DbConnection.getConnection();
     const groupRepository = conn.getRepository(Group);
-    const userRepository = conn.getRepository(User);
-    const group = await Group.getGroupInfo(groupRepository, userRepository, groupId);
+    const group = await Group.getGroupInfo(groupRepository, groupId);
 
     if (!group
         || group.owner.id !== requestingUser.id) {

--- a/sources/api/controllers/GroupController.ts
+++ b/sources/api/controllers/GroupController.ts
@@ -70,7 +70,8 @@ export async function groupInfo(req: Request, res: Response) {
 
     const conn = await DbConnection.getConnection();
     const groupRepository = conn.getRepository(Group);
-    const group = await Group.getGroupInfo(groupRepository, groupId);
+    const userRepository = conn.getRepository(User);
+    const group = await Group.getGroupAndMembers(groupRepository, userRepository, groupId);
 
     if (!group
         || group.members.findIndex(member => member.id === requestingUser.id) < 0) {

--- a/sources/model/entity/Group.ts
+++ b/sources/model/entity/Group.ts
@@ -72,11 +72,17 @@ export class Group {
         groupRepository: Repository<Group>,
         groupId: number
     ) : Promise<Group> {
-        return groupRepository
+        let group = await groupRepository
             .createQueryBuilder("groups")
             .leftJoinAndSelect("groups.owner", "owner")
             .where({group_id: groupId})
             .getOne();
+        if (!group) {
+            return null;
+        }
+
+        group.members = [];
+        return group;
     }
 
     /**

--- a/sources/model/entity/Group.ts
+++ b/sources/model/entity/Group.ts
@@ -51,9 +51,9 @@ export class Group {
         groupToUserRepository: Repository<GroupsToUsers>,
         group: Group
     ): Promise<Group> {
-        const relations = group.members.map(user => new GroupsToUsers(group.id, user.id));
+        const createdGroup = await groupRepository.save(group);
 
-        await groupRepository.save(group);
+        const relations = group.members.map(user => new GroupsToUsers(createdGroup.id, user.id));
         await groupToUserRepository.save(relations);
 
         return group;

--- a/sources/model/entity/Group.ts
+++ b/sources/model/entity/Group.ts
@@ -1,7 +1,3 @@
-//
-// Created by benard-g on 2018//07
-//
-
 import {Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Repository} from "typeorm";
 import {User} from "./User";
 import {GroupsToUsers} from "./GroupsToUsers";
@@ -33,68 +29,113 @@ export class Group {
         this.members = members;
     }
 
-    //
-    // Check if a Group satisfies the basic rules (name, ...)
-    //
+    /**
+     * @brief Check if a Group is valid and can be created
+     */
     public isValid() : boolean {
-        return this.name.length > 0;
+        return this.name.length > 0
+            && this.members.length >= 1;
     }
 
-    //
-    // Create Group
-    //
+    /**
+     * @brief Save a new Group in the database
+     *
+     * @param groupRepository           The Repository used to access Group resources
+     * @param groupToUserRepository     The Repository used to access GroupToUser resources
+     * @param group                     The Group to save
+     *
+     * @return The created Group
+     */
     static async createGroup(
         groupRepository: Repository<Group>,
-        groupToUsersRepository: Repository<GroupsToUsers>,
+        groupToUserRepository: Repository<GroupsToUsers>,
         group: Group
     ): Promise<Group> {
-        await groupRepository.save(group);
         const relations = group.members.map(user => new GroupsToUsers(group.id, user.id));
-        await groupToUsersRepository.save(relations);
+
+        await groupRepository.save(group);
+        await groupToUserRepository.save(relations);
+
         return group;
     }
 
-    //
-    // Get one Group by Id
-    //
+    /**
+     * @brief Get a Group (member list is not filled)
+     *
+     * @param groupRepository
+     * @param groupId
+     *
+     * @return The requested Group information on success
+     * @return null on error
+     */
     static async getGroupInfo(
         groupRepository: Repository<Group>,
-        userRepository: Repository<User>,
         groupId: number
     ) : Promise<Group> {
-        let group = await groupRepository
+        return groupRepository
             .createQueryBuilder("groups")
             .leftJoinAndSelect("groups.owner", "owner")
             .where({group_id: groupId})
             .getOne();
+    }
 
-        if (group) {
-            group.members = await this.getGroupMembers(userRepository, groupId);
+    /**
+     * @brief Get both a Group and its members
+     *
+     * @param groupRepository   The Repository used to access Group resources
+     * @param userRepository    The Repository used to access User resources
+     * @param groupId           The id of the Group
+     *
+     * @return The requested Groups with all its members in the member list on success
+     * @return null on error
+     */
+    static async getGroupAndMembers(
+        groupRepository: Repository<Group>,
+        userRepository: Repository<User>,
+        groupId: number
+    ) : Promise<Group> {
+        let group = await this.getGroupInfo(groupRepository, groupId);
+        if (!group) {
+            return null;
         }
 
+        group.members = await this.getGroupMembers(userRepository, groupId);
         return group;
     }
 
-    //
-    // Get Group members
-    //
+    /**
+     * @brief Get the Users of a Group
+     *
+     * @param userRepository    The Repository used to access User resources
+     * @param groupId           The id of the Group
+     *
+     * @return The list of Users of the requested Group on success
+     * @return null on error
+     */
     static async getGroupMembers(
         userRepository: Repository<User>,
         groupId: number
     ) : Promise<User[]> {
-        return await userRepository
+        return userRepository
             .createQueryBuilder()
             .innerJoinAndSelect(GroupsToUsers, "gtu", `gtu.user_id = "User"."id"`)
             .where("gtu.group_id = :group_id", {group_id: groupId})
             .getMany();
     }
 
+    /**
+     * @brief Delete a Group
+     *
+     * @param groupRepository           The Repository used to access Group resources
+     * @param groupToUserRepository     The Repository used to access GroupToUser resources
+     * @param groupId                   The id of the Group
+     */
     static async deleteGroup(
         groupRepository: Repository<Group>,
-        groupToUsersRepository: Repository<GroupsToUsers>,
+        groupToUserRepository: Repository<GroupsToUsers>,
         groupId: number
     ) : Promise<any> {
-        await groupToUsersRepository
+        await groupToUserRepository
             .createQueryBuilder()
             .delete()
             .where("group_id = :group_id", {group_id: groupId})

--- a/sources/utils/removeDuplicates.ts
+++ b/sources/utils/removeDuplicates.ts
@@ -1,19 +1,17 @@
-//
-// Created by benard-g on 2018/10/08
-//
-
-//
-// Remove duplicates entries in a list, keeping only the first occurrence
-//
+/**
+ * @brief Remove duplicate entries in a list
+ *
+ * @param list The list to filter
+ */
 export function removeDuplicates(list: string[]) : string[] {
-    let seenKeys: any = {};
+    let seenKeys = new Set<string>();
 
     return list.filter(value => {
-        if (seenKeys.hasOwnProperty(value)) {
+        if (seenKeys.has(value)) {
             return false;
         }
 
-        seenKeys[value] = true;
+        seenKeys.add(value);
         return true;
     });
 }


### PR DESCRIPTION
Rewrite Group Model

- Split Group getter so that you can fetch the member list only if necessary
- Rewrite function descriptions to follow JsDoc convention